### PR TITLE
Adding a GO wrapper around a C DXT implementation

### DIFF
--- a/dxt/dxt.go
+++ b/dxt/dxt.go
@@ -27,6 +27,7 @@ import (
   "image/color"
 )
 
+// DXTFlag is an int type used to specify which DXT algorithm to use.
 type DXTFlag int
 
 const (


### PR DESCRIPTION
This C implementation has been used by other SC4 tooling.
